### PR TITLE
Upgrade to version 3.7.0 of maven-compiler-plugin.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.2</version>
+          <version>3.7.0</version>
           <configuration>
             <source>${java.minimum.version}</source>
             <target>${java.minimum.version}</target>


### PR DESCRIPTION
This version of maven-compiler-plugin includes a bugfix that occurs on lots of java projects that prevents incremental compilation from working properly.  With this updated version of the plugin developers no longer have to constantly run `clean` as their first maven target anytime they are going to compile code.